### PR TITLE
Update Readme with edge case first time setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This repo contains the projects you'll work on throughout SPS.
 To get started:
 
 - Login to [Google Cloud Shell](https://ssh.cloud.google.com/cloudshell/editor)
-- Clone this repo: `git clone https://github.com/google/software-product-sprint.git`
+- Clone this repo: `cd; git clone https://github.com/google/software-product-sprint.git`
 - Open the GitHub setup walkthrough: `teachme ~/software-product-sprint/walkthroughs/week-0-setup/github-setup-walkthrough.md`
+  - If the tutorial panel does not open or display the walkthrough contents, try refreshing the page.
 
 Then follow the on-screen instructions to set up your repo.


### PR DESCRIPTION
When logging into cloudshell editor for the first time, users are automatically put in the directory ~/cloudshell_open/cloud-shell-tutorials. Updated the instructions to include a `cd` before `git clone` ensuring that users are put in the root directory before starting the tutorial.

Added additional instructions to refresh the page when users run into an issue where the tutorial panel gets stuck in a blank state.