### PR TITLE
Disable caching of static resources

### DIFF
--- a/portfolio/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/portfolio/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,8 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <!-- prevent unwanted caching when accessing via the web preview server -->
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>


### PR DESCRIPTION
This speeds up reloads when accessing via the web preview server in Cloud Shell.

This was driving me crazy, as changes to static files were not showing up for several minutes (across multiple browsers, forcing a reload) due to proxy-side caching.