### PR TITLE
Clarify that GitHub repo URL starts with https://

### DIFF
--- a/walkthroughs/week-0-setup/github-setup-walkthrough.md
+++ b/walkthroughs/week-0-setup/github-setup-walkthrough.md
@@ -62,7 +62,8 @@ At this point you should have an empty repo.
 
 ## Link Your Repo
 
-In your GitHub repo page, find your repo's URL. It should end in `.git`, like
+In your GitHub repo page, find your repo's URL. It should start with `https://`
+and end in `.git`, like
 `https://github.com/your-username/your-repo-name.git`. Copy that URL.
 
 To link this local copy to your GitHub project, execute this command:


### PR DESCRIPTION
There are URLs starting with "git@github.com" (to use with SSH) and "https://" URLs (to use with HTTPS). Since we're using HTTPS, clarify that the URL has to start with "https://".