### PR TITLE
Add static-files to appengine-web.xml.

### DIFF
--- a/walkthroughs/week-1-web-development/examples/stanley/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-1-web-development/examples/stanley/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-2-server/examples/favorite-color/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/favorite-color/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-2-server/examples/form-submission/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/form-submission/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-2-server/examples/page-view-counter/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/page-view-counter/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-2-server/examples/random-quotes/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/random-quotes/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-2-server/examples/request-debugger/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/request-debugger/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-2-server/examples/server-stats/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/server-stats/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-2-server/examples/subtraction-game/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/subtraction-game/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-2-server/examples/text-processor/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/text-processor/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-2-server/examples/todo-list/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/todo-list/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/authentication/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/authentication/examples/shoutbox-v3/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/shoutbox-v3/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/authentication/examples/user-nicknames/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/user-nicknames/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world-fetch/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world-fetch/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world-jsp/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world-jsp/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/maps/examples/google-tour/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/google-tour/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/maps/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/maps/examples/info-window/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/info-window/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/maps/examples/marker-storage/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/marker-storage/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/maps/examples/marker/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/marker/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/maps/examples/ufos/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/ufos/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/sentiment-analysis/examples/sentiment-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/sentiment-analysis/examples/sentiment-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-3-libraries/translation/examples/minimal-google-translate/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/translation/examples/minimal-google-translate/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>

--- a/walkthroughs/week-4-tdd/project/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-tdd/project/src/main/webapp/WEB-INF/appengine-web.xml
@@ -5,4 +5,7 @@
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>
+  <static-files>
+    <include path="/**" expiration="0" />
+  </static-files>
 </appengine-web-app>


### PR DESCRIPTION
This is a workaround for App Engine's aggressive caching, which results in browsers seeing old versions of files. Specifying the `static-files` list tells App Engine not to cache anything.