### PR TITLE
Upgrade project to the cloud-sdk based plugin

### DIFF
--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -3,4 +3,4 @@ This directory is where you'll write all of your code!
 By default it contains a barebones web app. To run a local server, execute this
 command:
 
-mvn appengine:devserver
+`mvn package appengine:run`

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/portfolio/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/portfolio/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-1-web-development/examples/stanley/pom.xml
+++ b/walkthroughs/week-1-web-development/examples/stanley/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-1-web-development/examples/stanley/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-1-web-development/examples/stanley/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-1-web-development/portfolio-walkthrough.md
+++ b/walkthroughs/week-1-web-development/portfolio-walkthrough.md
@@ -65,12 +65,13 @@ cd portfolio
 Then execute this command:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
-This command tells Maven to run an App Engine development server, which is
-useful for testing changes before deploying your site publicly. You'll run this
-command a lot over the next few weeks!
+This command tells Maven to package your application into a `.war` web archive
+and run an App Engine development server, which is useful for testing changes 
+before deploying your site publicly. You'll run this command a lot over the next
+few weeks!
 
 The first time you run this command, Maven will automatically download all of
 the libraries and files required to run a server, so it might take a few
@@ -112,7 +113,7 @@ changes. Press `ctrl + c` in the console to shut down your server, and then run
 the devserver command again:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 **Tip:** You can press the up arrow key to cycle through previous commands
@@ -147,7 +148,7 @@ Deploy the example webpage by `cd`-ing into the `stanley` directory and then
 running a dev server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Then look through the files in the `stanley` project to see an example of HTML,
@@ -282,7 +283,7 @@ Remember, to run a dev server, you `cd` into a directory that contains a
 `pom.xml` file, and then you execute this command:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 When you see `Dev App Server is now running` in the console, click the
@@ -341,15 +342,15 @@ To deploy to a live server:
 -   Find the **Project ID** on that page.
 -   Open the
     <walkthrough-editor-open-file
-        filePath="software-product-sprint/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-      appengine-web.xml
+        filePath="software-product-sprint/portfolio/pom.xml">
+      pom.xml
     </walkthrough-editor-open-file>
     file.
 -   Change `YOUR_PROJECT_ID_HERE` to your project ID.
 -   Execute this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 -   The first time you run this command, the console will give you a link. Open

--- a/walkthroughs/week-2-server/comments-walkthrough.md
+++ b/walkthroughs/week-2-server/comments-walkthrough.md
@@ -156,14 +156,14 @@ world, you can deploy it to your live server!
 
 Last week, you should have added your project ID to your
 <walkthrough-editor-open-file
-    filePath="software-product-sprint/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+    filePath="software-product-sprint/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file. If so, you can deploy to your live server by executing this command from
 the `portfolio` directory:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 -   The first time you run this command, the console will give you a link. Open

--- a/walkthroughs/week-2-server/examples/favorite-color/pom.xml
+++ b/walkthroughs/week-2-server/examples/favorite-color/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-2-server/examples/favorite-color/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/favorite-color/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-2-server/examples/form-submission/pom.xml
+++ b/walkthroughs/week-2-server/examples/form-submission/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-2-server/examples/form-submission/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/form-submission/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-2-server/examples/page-view-counter/pom.xml
+++ b/walkthroughs/week-2-server/examples/page-view-counter/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-2-server/examples/page-view-counter/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/page-view-counter/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-2-server/examples/random-quotes/pom.xml
+++ b/walkthroughs/week-2-server/examples/random-quotes/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-2-server/examples/random-quotes/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/random-quotes/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-2-server/examples/request-debugger/pom.xml
+++ b/walkthroughs/week-2-server/examples/request-debugger/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-2-server/examples/request-debugger/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/request-debugger/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-2-server/examples/server-stats/pom.xml
+++ b/walkthroughs/week-2-server/examples/server-stats/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-2-server/examples/server-stats/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/server-stats/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-2-server/examples/subtraction-game/pom.xml
+++ b/walkthroughs/week-2-server/examples/subtraction-game/pom.xml
@@ -33,9 +33,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-2-server/examples/subtraction-game/pom.xml
+++ b/walkthroughs/week-2-server/examples/subtraction-game/pom.xml
@@ -23,6 +23,7 @@
       <version>4.0.1</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>

--- a/walkthroughs/week-2-server/examples/subtraction-game/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/subtraction-game/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-2-server/examples/text-processor/pom.xml
+++ b/walkthroughs/week-2-server/examples/text-processor/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-2-server/examples/text-processor/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/text-processor/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-2-server/examples/todo-list/pom.xml
+++ b/walkthroughs/week-2-server/examples/todo-list/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
+      <version>1.9.78</version>
     </dependency>
 
     <dependency>

--- a/walkthroughs/week-2-server/examples/todo-list/pom.xml
+++ b/walkthroughs/week-2-server/examples/todo-list/pom.xml
@@ -42,9 +42,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-2-server/examples/todo-list/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-server/examples/todo-list/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-2-server/step-1-servlets-walkthrough.md
+++ b/walkthroughs/week-2-server/step-1-servlets-walkthrough.md
@@ -78,7 +78,7 @@ To see this in action, `cd` into the `page-view-counter` directory and then run
 a development server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Run this command and then click the

--- a/walkthroughs/week-2-server/step-2-fetch-walkthrough.md
+++ b/walkthroughs/week-2-server/step-2-fetch-walkthrough.md
@@ -66,7 +66,7 @@ Confirm that this works by `cd`-ing into the `random-quotes` directory and
 running a dev server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Run this command and then click the

--- a/walkthroughs/week-2-server/step-4-post-walkthrough.md
+++ b/walkthroughs/week-2-server/step-4-post-walkthrough.md
@@ -73,7 +73,7 @@ To see this example in action, `cd` into the `text-processor` directory and
 then run a development server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Try submitting different values in the form and see how they're handled on the

--- a/walkthroughs/week-2-server/step-5-datastore-walkthrough.md
+++ b/walkthroughs/week-2-server/step-5-datastore-walkthrough.md
@@ -65,7 +65,7 @@ file:
 <dependency>
   <groupId>com.google.appengine</groupId>
   <artifactId>appengine-api-1.0-sdk</artifactId>
-  <version>1.9.59</version>
+  <version>1.9.78</version>
 </dependency>
 ```
 

--- a/walkthroughs/week-3-libraries/authentication/authentication-walkthrough.md
+++ b/walkthroughs/week-3-libraries/authentication/authentication-walkthrough.md
@@ -241,14 +241,14 @@ you can deploy it to your live server!
 
 Your
 <walkthrough-editor-open-file
-    filePath="software-product-sprint/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+    filePath="software-product-sprint/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-3-libraries/authentication/authentication-walkthrough.md
+++ b/walkthroughs/week-3-libraries/authentication/authentication-walkthrough.md
@@ -72,7 +72,7 @@ file:
 <dependency>
   <groupId>com.google.appengine</groupId>
   <artifactId>appengine-api-1.0-sdk</artifactId>
-  <version>1.9.59</version>
+  <version>1.9.78</version>
 </dependency>
 ```
 

--- a/walkthroughs/week-3-libraries/authentication/examples/hello-world/pom.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/hello-world/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
+      <version>1.9.78</version>
     </dependency>
 
   </dependencies>

--- a/walkthroughs/week-3-libraries/authentication/examples/hello-world/pom.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/hello-world/pom.xml
@@ -36,9 +36,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/authentication/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/authentication/examples/shoutbox-v3/pom.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/shoutbox-v3/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
+      <version>1.9.78</version>
     </dependency>
 
   </dependencies>

--- a/walkthroughs/week-3-libraries/authentication/examples/shoutbox-v3/pom.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/shoutbox-v3/pom.xml
@@ -36,9 +36,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/authentication/examples/shoutbox-v3/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/shoutbox-v3/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/authentication/examples/user-nicknames/pom.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/user-nicknames/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
+      <version>1.9.78</version>
     </dependency>
 
   </dependencies>

--- a/walkthroughs/week-3-libraries/authentication/examples/user-nicknames/pom.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/user-nicknames/pom.xml
@@ -36,9 +36,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/authentication/examples/user-nicknames/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/authentication/examples/user-nicknames/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/blobstore/blobstore-walkthrough.md
+++ b/walkthroughs/week-3-libraries/blobstore/blobstore-walkthrough.md
@@ -53,7 +53,7 @@ file:
 <dependency>
   <groupId>com.google.appengine</groupId>
   <artifactId>appengine-api-1.0-sdk</artifactId>
-  <version>1.9.59</version>
+  <version>1.9.78</version>
 </dependency>
 ```
 

--- a/walkthroughs/week-3-libraries/blobstore/blobstore-walkthrough.md
+++ b/walkthroughs/week-3-libraries/blobstore/blobstore-walkthrough.md
@@ -295,14 +295,14 @@ you can deploy it to your live server!
 
 Your
 <walkthrough-editor-open-file
-    filePath="software-product-sprint/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+    filePath="software-product-sprint/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world-fetch/pom.xml
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world-fetch/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world-fetch/pom.xml
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world-fetch/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
+      <version>1.9.78</version>
     </dependency>
   </dependencies>
 

--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world-jsp/pom.xml
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world-jsp/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world-jsp/pom.xml
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world-jsp/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
+      <version>1.9.78</version>
     </dependency>
   </dependencies>
 

--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world/pom.xml
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world/pom.xml
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
+      <version>1.9.78</version>
     </dependency>
   </dependencies>
 

--- a/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/README.md
+++ b/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/README.md
@@ -11,7 +11,7 @@ environment variable is set and that you've enabled the
 and then execute this command:
 
 ```
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Then open a web browser to `http://localhost:8080/index.jsp`.

--- a/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/pom.xml
+++ b/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/pom.xml
@@ -27,13 +27,13 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
+      <version>1.9.78</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-vision</artifactId>
-      <version>1.70.0</version>
+      <version>1.99.1</version>
     </dependency>
   </dependencies>
 

--- a/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/pom.xml
+++ b/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/pom.xml
@@ -40,9 +40,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/image-analysis/image-analysis-walkthrough.md
+++ b/walkthroughs/week-3-libraries/image-analysis/image-analysis-walkthrough.md
@@ -178,14 +178,14 @@ you can deploy it to your live server!
 
 Your
 <walkthrough-editor-open-file
-    filePath="software-product-sprint/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+    filePath="software-product-sprint/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-3-libraries/maps/examples/google-tour/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/google-tour/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/maps/examples/google-tour/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/google-tour/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/maps/examples/hello-world/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/hello-world/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/maps/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/maps/examples/info-window/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/info-window/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/maps/examples/info-window/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/info-window/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/maps/examples/marker-storage/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/marker-storage/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.5</version>
+      <version>2.8.6</version>
     </dependency>
 
     <dependency>

--- a/walkthroughs/week-3-libraries/maps/examples/marker-storage/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/marker-storage/pom.xml
@@ -46,9 +46,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/maps/examples/marker-storage/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/marker-storage/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
+      <version>1.9.78</version>
     </dependency>
 
     <dependency>

--- a/walkthroughs/week-3-libraries/maps/examples/marker-storage/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/marker-storage/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/maps/examples/marker/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/marker/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/maps/examples/marker/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/marker/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/maps/examples/ufos/README.md
+++ b/walkthroughs/week-3-libraries/maps/examples/ufos/README.md
@@ -12,7 +12,7 @@ found by searching on
 You can run this locally by executing this command:
 
 ```
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 ![UFO data on map](screenshot-1.png)

--- a/walkthroughs/week-3-libraries/maps/examples/ufos/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/ufos/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/maps/examples/ufos/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/ufos/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.5</version>
+      <version>2.8.6</version>
     </dependency>
   </dependencies>
 

--- a/walkthroughs/week-3-libraries/maps/examples/ufos/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/ufos/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/maps/maps-walkthrough.md
+++ b/walkthroughs/week-3-libraries/maps/maps-walkthrough.md
@@ -56,7 +56,7 @@ file to include your API key where it currently contains `YOUR_API_KEY`. Then
 `cd` into the `hello-world` directory and run a dev server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 You should see a webpage that shows a Google Map.
@@ -206,14 +206,14 @@ deploy it to your live server!
 
 Your
 <walkthrough-editor-open-file
-    filePath="software-product-sprint/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+    filePath="software-product-sprint/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-3-libraries/sentiment-analysis/examples/sentiment-analyzer/README.md
+++ b/walkthroughs/week-3-libraries/sentiment-analysis/examples/sentiment-analyzer/README.md
@@ -11,7 +11,7 @@ environment variable is set and that you've enabled the
 and then execute this command:
 
 ```
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Then navigate to `http://localhost:8080`.

--- a/walkthroughs/week-3-libraries/sentiment-analysis/examples/sentiment-analyzer/pom.xml
+++ b/walkthroughs/week-3-libraries/sentiment-analysis/examples/sentiment-analyzer/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/sentiment-analysis/examples/sentiment-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/sentiment-analysis/examples/sentiment-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/sentiment-analysis/sentiment-analysis-walkthrough.md
+++ b/walkthroughs/week-3-libraries/sentiment-analysis/sentiment-analysis-walkthrough.md
@@ -176,14 +176,14 @@ deploy it to your live server!
 
 Your
 <walkthrough-editor-open-file
-    filePath="software-product-sprint/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+    filePath="software-product-sprint/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-3-libraries/translation/examples/minimal-google-translate/README.md
+++ b/walkthroughs/week-3-libraries/translation/examples/minimal-google-translate/README.md
@@ -10,5 +10,5 @@ environment variable is set and that you've enabled the
 and then execute this command:
 
 ```
-mvn appengine:devserver
+mvn package appengine:run
 ```

--- a/walkthroughs/week-3-libraries/translation/examples/minimal-google-translate/pom.xml
+++ b/walkthroughs/week-3-libraries/translation/examples/minimal-google-translate/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-libraries/translation/examples/minimal-google-translate/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-libraries/translation/examples/minimal-google-translate/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-libraries/translation/translation-walkthrough.md
+++ b/walkthroughs/week-3-libraries/translation/translation-walkthrough.md
@@ -174,14 +174,14 @@ deploy it to your live server!
 
 Your
 <walkthrough-editor-open-file
-    filePath="software-product-sprint/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+    filePath="software-product-sprint/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-4-tdd/intro/pom.xml
+++ b/walkthroughs/week-4-tdd/intro/pom.xml
@@ -36,9 +36,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-tdd/project/calendar-walkthrough.md
+++ b/walkthroughs/week-4-tdd/project/calendar-walkthrough.md
@@ -96,7 +96,7 @@ your algorithm.
 To run the web application, run a server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Then open the web preview to view a webpage that shows a user interface that

--- a/walkthroughs/week-4-tdd/project/pom.xml
+++ b/walkthroughs/week-4-tdd/project/pom.xml
@@ -43,9 +43,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <projectId>YOUR_PROJECT_ID_HERE</projectId>
+          <version>1</version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-tdd/project/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-tdd/project/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>


### PR DESCRIPTION
This is a pretty big change as the plugin behavior is not drop-in compatible. The advantage to this is that deploying "actually works".

The `appengine:update` flow, as well as `gcloud app deploy` were not able to push an actually functioning configuration. The former failed with `HTTP/500` errors while the latter only sent static files and no classes/.war file.
This issue appears to be independent of billing status of the project and failed repeatedly where the new flow works.

This change really needs to be tested thoroughly (incl. starting with a blank project/shell) to find further issues. I've been over the docs a few times, searching/replacing critical differences, but I'm sure I've missed some references that may have changed.

Given the timing of the program, let me know if this is something you're at all comfortable with before I invest more time in the upgrade :)