### PR TITLE
Use non-deprecated appengine maven plugin for deploying portfolio

### DIFF
--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -4,3 +4,7 @@ By default it contains a barebones web app. To run a local server, execute this
 command:
 
 mvn appengine:devserver
+
+or 
+
+mvn appengine:run

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -27,10 +27,26 @@
 
   <build>
     <plugins>
+      <!-- Old plugin that is deprecated for deployment but can be used for local testing. 
+      Enables usage of `mvn appengine:devserver` for local testing, which is in many of the walkthroughs. 
+      Cannot deploy with `mvn appengine:update` because it's deprecated. -->
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
         <version>1.9.71</version>
+      </plugin>
+      <!-- New plugin necessary to deploy because old plugin is deprecated. 
+      Can use `mvn appengine:run` for local testing. 
+      Can use `mvn appengine:deploy` for deploying. -->
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>2.2.0</version>
+        <!-- TODO: uncomment configuration block and provide project ID. -->
+        <!-- <configuration>
+            <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+            <deploy.version>1</deploy.version>
+        </configuration> -->
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-1-web-development/portfolio-walkthrough.md
+++ b/walkthroughs/week-1-web-development/portfolio-walkthrough.md
@@ -341,15 +341,18 @@ To deploy to a live server:
 -   Find the **Project ID** on that page.
 -   Open the
     <walkthrough-editor-open-file
-        filePath="software-product-sprint/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-      appengine-web.xml
+        filePath="software-product-sprint/portfolio/pom.xml">
+      pom.xml
     </walkthrough-editor-open-file>
     file.
--   Change `YOUR_PROJECT_ID_HERE` to your project ID.
+-   Uncomment <configuration>...</configuration> and change `YOUR_PROJECT_ID_HERE` to your project ID.
+-   Enable Cloud Build on your project by visiting https://console.developers.google.com/apis/api/cloudbuild.googleapis.com/overview?project=<YOUR_PROJECT_ID_HERE>
+    - Will require enabling billing. See doc for Intern Dev Environment Setup https://docs.google.com/document/d/1_zKf_Vpb1lxnWLDhQ6IGcA6W95UBufr06SmmoJZY7iE/edit#heading=h.wzgtvu2xiuh3. You will be unable to deploy applications after November 30, 2019 without adding a billing instrument to your project. Please add one at https://console.cloud.google.com/billing/linkedaccount?<YOUR_PROJECT_ID_HERE>
+
 -   Execute this command:
 
 ```bash
-mvn appengine:update
+mvn appengine:deploy
 ```
 
 -   The first time you run this command, the console will give you a link. Open


### PR DESCRIPTION
I might be wrong because I haven't set up billing for my experimental project (and therefore haven't deployed successfully), but following the instructions and trying to deploy with `mvn appengine:update` was failing with "Deployments using appcfg are no longer supported. See https://cloud.google.com/appengine/docs/deprecations"

To get further in the deployment process, I think it needs to use a non-deprecated plugin to deploy. Using `mvn appengine:devserver` only works for locally testing with the old plugin. `mvn appengine:run` can be used to test locally for both.

Current plugin (deprecated): https://github.com/GoogleCloudPlatform/gcloud-maven-plugin
New plugin (not-deprecated): https://github.com/GoogleCloudPlatform/app-maven-plugin