### PR TITLE
Use provided formInputElementName parameter

### DIFF
--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world-fetch/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world-fetch/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
@@ -63,7 +63,7 @@ public class FormHandlerServlet extends HttpServlet {
   private String getUploadedFileUrl(HttpServletRequest request, String formInputElementName) {
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
-    List<BlobKey> blobKeys = blobs.get("image");
+    List<BlobKey> blobKeys = blobs.get(formInputElementName);
 
     // User submitted form without selecting a file, so we can't get a URL. (dev server)
     if (blobKeys == null || blobKeys.isEmpty()) {

--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world-jsp/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world-jsp/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
@@ -63,7 +63,7 @@ public class FormHandlerServlet extends HttpServlet {
   private String getUploadedFileUrl(HttpServletRequest request, String formInputElementName) {
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
-    List<BlobKey> blobKeys = blobs.get("image");
+    List<BlobKey> blobKeys = blobs.get(formInputElementName);
 
     // User submitted form without selecting a file, so we can't get a URL. (dev server)
     if (blobKeys == null || blobKeys.isEmpty()) {


### PR DESCRIPTION
Use provided formInputElementName parameter rather than the hardcoded "image" string. 