### PR TITLE
force cache-control response header on all requests

### DIFF
--- a/portfolio/src/main/java/com/google/sps/ServerMain.java
+++ b/portfolio/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-1-web-development/examples/stanley/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-1-web-development/examples/stanley/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-2-server/examples/form-submission/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-2-server/examples/form-submission/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-2-server/examples/page-view-counter/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-2-server/examples/page-view-counter/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-2-server/examples/server-date/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-2-server/examples/server-date/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-2-server/examples/server-stats/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-2-server/examples/server-stats/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-2-server/examples/text-processor/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-2-server/examples/text-processor/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/charts/examples/bigfoot-sightings/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/charts/examples/bigfoot-sightings/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/charts/examples/favorite-colors/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/charts/examples/favorite-colors/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/charts/examples/hello-world/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/charts/examples/hello-world/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/cloud-storage/examples/hello-world/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/cloud-storage/examples/hello-world/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/datastore/examples/todo-list/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/datastore/examples/todo-list/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/maps/examples/google-tour/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/maps/examples/google-tour/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/maps/examples/hello-world/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/maps/examples/hello-world/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/maps/examples/info-window/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/maps/examples/info-window/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/maps/examples/marker-storage/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/maps/examples/marker-storage/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/maps/examples/marker/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/maps/examples/marker/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/maps/examples/ufos/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/maps/examples/ufos/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/sentiment-analysis/examples/sentiment-analyzer/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/sentiment-analysis/examples/sentiment-analyzer/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();

--- a/walkthroughs/week-3-libraries/translation/examples/minimal-google-translate/src/main/java/com/google/sps/ServerMain.java
+++ b/walkthroughs/week-3-libraries/translation/examples/minimal-google-translate/src/main/java/com/google/sps/ServerMain.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -37,7 +38,8 @@ public class ServerMain {
         ".*/target/classes/|.*\\.jar");
 
     // Handle static resources, e.g. html files.
-    webAppContext.addServlet(DefaultServlet.class, "/");
+    ServletHolder defaultServletHolder = webAppContext.addServlet(DefaultServlet.class, "/");
+    defaultServletHolder.setInitParameter("cacheControl", "no-store, max-age=0");
 
     // Start the server! 🚀
     server.start();


### PR DESCRIPTION
This resolves caching issues with the local server when switching between walkthroughs and portfolio projects.