### PR TITLE
Add git hook setup 

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# Configures pre-commit hooks for the git repository. 
+#
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for other hooks you can add.
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: detect-private-key 

--- a/setup-pre-commit.bash
+++ b/setup-pre-commit.bash
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Requires: python3, pip3.
+#
+# Installs and configures the pre-submit checks found in .pre-commit-config.yaml
+# If you'd like to customize your pre-submit checks, see the yaml config.
+
+pip3 install pre-commit
+pre-commit install

--- a/walkthroughs/week-0-setup/github-setup-walkthrough.md
+++ b/walkthroughs/week-0-setup/github-setup-walkthrough.md
@@ -145,6 +145,24 @@ and then your name:
 git config --global user.name "Your Name"
 ```
 
+## Setup Git Hooks
+
+[Git hooks](https://githooks.com/) are scripts that run before or after a Git
+events such as: `commit`. Hooks are used to increase productivity, like
+automatically formatting code before commiting it. Setup pre-commit hooks:
+
+```bash
+bash setup-pre-commit.bash
+```
+
+This will install the hooks listed in `.pre-submit-config.yaml`, which by
+default contains a single check to prevent you from accidentally committing
+private keys; don't worry, this doesn't come up until Week 3! You can add
+whatever hooks you'd like by updating the `.pre-submit-config.yaml` file and
+rerunning the setup script. The framework we use,
+[Pre-commit ](https://pre-commit.com/index.html), has more documentation on how
+to do this.
+
 ## Modify README
 
 To test that everything is connected, modify your


### PR DESCRIPTION
There have been multiple instances of SPS students accidentally committing private keys.  To prevent this from happening, this PR sets up pre-commit git hooks for the students using the eponymous [package](https://pre-commit.com/#intro). 


The default hook `detect-private-key` prevents private keys from being included in a commit. Technically this just [checks for a string](https://github.com/pre-commit/pre-commit-hooks/blob/master/pre_commit_hooks/detect_private_key.py) indicating a private key but false positives can easily be committed with `git commit --no-verify`.

Example output:

```
$ git commit -m "Add private key"
Detect Private Key.......................................................Failed
- hook id: detect-private-key
- exit code: 1

Private key found: walkthroughs/private-key.json
```